### PR TITLE
Add support for scanning IPv6 targets

### DIFF
--- a/padcheck.go
+++ b/padcheck.go
@@ -329,8 +329,7 @@ func scanHost(hostname, serverName string, cipherIndex int) error {
 		tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
 		tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
 	}
-	cipherList := []uint16 {allCiphers[cipherIndex]};
-
+	cipherList := []uint16{allCiphers[cipherIndex]}
 	availableCipher, availableProtocol, err := SupportedCipherTest(hostname, serverName, cipherList, 0x0303)
 	if err != nil {
 		if *verboseLevel > 0 {
@@ -444,13 +443,13 @@ func worker(hosts <-chan string, done *sync.WaitGroup) {
 		var hostnameParts []string
 
 		// Attempt to find hostname and port from argument
-		x,y,z := net.SplitHostPort(hostname)
-		if z == nil {
-			hostnameParts = []string{x, y}
+		host, port, err := net.SplitHostPort(hostname)
+		if err == nil {
+			hostnameParts = []string{host, port}
 		} else {
 			// If bare hostname is IPv6, remove any supplied brackets
-			hostname = strings.Replace(hostname,"[","",-1)
-			hostname = strings.Replace(hostname,"]","",-1)
+			hostname = strings.Replace(hostname, "[", "", -1)
+			hostname = strings.Replace(hostname, "]", "", -1)
 
 			// Default to HTTPS
 			hostnameParts = []string{hostname, "443"}
@@ -477,7 +476,9 @@ func worker(hosts <-chan string, done *sync.WaitGroup) {
 				if addressList[i].To4() != nil || addressList[i].To16() != nil {
 					address = addressList[i].String()
 					// If the hostname resolves to an IPv6 address make sure it is properly formatted
-					if addressList[i].To16() != nil { address = "[" + address + "]" }
+					if addressList[i].To16() != nil {
+						address = "[" + address + "]"
+					}
 					break
 				}
 			}
@@ -486,7 +487,7 @@ func worker(hosts <-chan string, done *sync.WaitGroup) {
 			}
 		} else {
 			// Host appars to be an IP address
-			if net.ParseIP(hostnameParts[0]) != nil && strings.Contains(hostnameParts[0],":") {
+			if net.ParseIP(hostnameParts[0]) != nil && strings.Contains(hostnameParts[0], ":") {
 				// If the hostname is an IPv6 address make sure it is properly formatted
 				hostnameParts[0] = "[" + hostnameParts[0] + "]"
 			}

--- a/padcheck.go
+++ b/padcheck.go
@@ -448,13 +448,17 @@ func worker(hosts <-chan string, done *sync.WaitGroup) {
 		if z == nil {
 			hostnameParts = []string{x, y}
 		} else {
+			// If bare hostname is IPv6, remove any supplied brackets
+			hostname = strings.Replace(hostname,"[","",-1)
+			hostname = strings.Replace(hostname,"]","",-1)
+
 			// Default to HTTPS
 			hostnameParts = []string{hostname, "443"}
 		}
 
 		address := ""
 		// Determine if the host is not an IPv4 or IPv6 address
-		if net.ParseIP(hostnameParts[0][1:len(hostnameParts[0])-1]) == nil && net.ParseIP(hostnameParts[0]) == nil {
+		if net.ParseIP(hostnameParts[0]) == nil {
 			// Host appears to be an FQDN
 			addressList, err := net.LookupIP(hostnameParts[0])
 			if err != nil {

--- a/padcheck.go
+++ b/padcheck.go
@@ -525,6 +525,7 @@ func main() {
 
 	if *showHelp {
 		fmt.Fprintf(os.Stderr, "This tool tests how a server responds to various CBC padding errors.\n\nFive HTTPS GET requests will be made to the target with different padding modes.\nFirst a good padding and then the errors:\n\t1 - Invalid MAC with Valid Padding (0-length pad)\n\t2 - Missing MAC with Incomplete/Invalid Padding (255-length pad)\n\t3 - Typical POODLE condition (incorrect bytes followed by correct length)\n\t4 - All padding bytes set to 0x80 (integer overflow attempt)\n\nA file containing a list of hosts to scanned with worker threads can be specified via -hosts\n")
+		os.Exit(0)
 	}
 
 	if len(*hostsFile) > 0 {


### PR DESCRIPTION
I found that I had a need to scan for this vulnerability, however I am in an environment that also has IPv6 systems that needed to be scanned. I've added some logic to handle IPv6 addresses in the following formats (I tested on the command line as well as in a file supplied via -hosts):

```
[2604:1380:4111:200::3]:443
[2604:1380:4111:200::3]
2604:1380:4111:200::3
ipv6.icanhazip.com:443
ipv6.icanhazip.com
```

Additionally, I've verified that the Go patch will also apply to the Go 1.11.10 source.